### PR TITLE
Check for selector, not class when retrieving request object from AFURLSessionManager

### DIFF
--- a/AFNetworkActivityLogger.m
+++ b/AFNetworkActivityLogger.m
@@ -30,8 +30,8 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
     NSURLRequest *request = nil;
     if ([[notification object] isKindOfClass:[AFURLConnectionOperation class]]) {
         request = [(AFURLConnectionOperation *)[notification object] request];
-    } else if ([[notification object] isKindOfClass:[NSURLSessionTask class]]) {
-        request = [(NSURLSessionTask *)[notification object] originalRequest];
+    } else if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
+        request = [[notification object] originalRequest];
     }
 
     return request;


### PR DESCRIPTION
The class of the object associated with a notification sent from AFURLSessionManager may not be NSURLSessionTask e.g. [[notification object] class] => __NSCFLocalDataTask.
Check for respondsToSelector: in order to retrieve the request instead.
