### PR TITLE
Updating AFNetworking dependency from 2.0 to 2.x

### DIFF
--- a/AFNetworkActivityLogger.podspec
+++ b/AFNetworkActivityLogger.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '6.0'
 
-  s.dependency 'AFNetworking/NSURLSession', '~> 2.0'
+  s.dependency 'AFNetworking/NSURLSession', '~> 2'
 end


### PR DESCRIPTION
Loosening the restriction on which version of AFNetworking the logger depends on now that 2.1/2.2 are out
