### PR TITLE
Add logging delegate to AFNetworkActivityLogger

### DIFF
--- a/AFNetworkActivityLogger.podspec
+++ b/AFNetworkActivityLogger.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name     = 'AFNetworkActivityLogger'
-  s.version  = '2.0.3'
+  s.version  = '2.0.4'
   s.license  = 'MIT'
   s.summary  = 'AFNetworking 2.0 Extension for Network Request Logging'
   s.homepage = 'https://github.com/AFNetworking/AFNetworkActivityLogger'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
-  s.source   = { :git => 'https://github.com/AFNetworking/AFNetworkActivityLogger.git', :tag => '2.0.3' }
+  s.source   = { :git => 'https://github.com/AFNetworking/AFNetworkActivityLogger.git', :tag => '2.0.4' }
   s.source_files = 'AFNetworkActivityLogger'
   s.requires_arc = true
   s.ios.deployment_target = '6.0'

--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.h
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.h
@@ -32,6 +32,16 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestLoggerLevel) {
 };
 
 /**
+ * `AFNetworkActivityLoggerLogDelegate` protocol defines a way for developers to route log messages
+ *   in any way they'd like.
+ */
+@protocol AFNetworkActivityLoggerLogDelegate <NSObject>
+
+- (void)afNetworkLog:(NSString *)logMessage level:(AFHTTPRequestLoggerLevel)logLevel error:(NSError *)logError;
+
+@end
+
+/**
  `AFNetworkActivityLogger` logs requests and responses made by AFNetworking, with an adjustable level of detail.
  
  Applications should enable the shared instance of `AFNetworkActivityLogger` in `AppDelegate -application:didFinishLaunchingWithOptions:`:
@@ -53,6 +63,15 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestLoggerLevel) {
  @discussion Each notification has an associated `NSURLRequest`. To filter out request and response logging, such as all network activity made to a particular domain, this predicate can be set to match against the appropriate URL string pattern.
  */
 @property (nonatomic, strong) NSPredicate *filterPredicate;
+
+
+/**
+ * The delegate that handles actual logging of the log message.
+ * 
+ * The default AFNetworkActivityLoggerLogDelegate is the instance of `AFHTTPRequestLoggerLevel`,
+ *   and uses NSLog to log all messages.
+ */
+@property (nonatomic, strong) id<AFNetworkActivityLoggerLogDelegate> logDelegate;
 
 /**
  Returns the shared logger instance.


### PR DESCRIPTION
- Allows consumer to route log messages as desired
- Added `@protocol AFNetworkActivityLoggerLogDelegate`
- Only method - `- (void)afNetworkLog:(NSString *)logMessage level:(AFHTTPRequestLoggerLevel)logLevel error:(NSError *)logError;`
- Bump podspec version to 2.0.4
