### PR TITLE
Added "request" selector

### DIFF
--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.m
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.m
@@ -32,6 +32,8 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
         request = [(AFURLConnectionOperation *)[notification object] request];
     } else if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
         request = [[notification object] originalRequest];
+    } else if ([[notification object] respondsToSelector:@selector(request)]) {
+        request = [[notification object] request];
     }
 
     return request;


### PR DESCRIPTION
TL;DR
Added “request” selector in AFNetworkRequestFromNotification to log
request from NSMutableURLRequest

I added another way to find the request object from the notification object. Due to my architecture it's necessary that I use NSMutableURLRequest. These requests will not be logged as long as the request is not read from the notification object.
