### PR TITLE
to print the Unicode string in Dictionary

### DIFF
--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.m
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.m
@@ -157,7 +157,10 @@ static void * AFNetworkRequestStartDate = &AFNetworkRequestStartDate;
     if ([[notification object] respondsToSelector:@selector(responseString)]) {
         responseObject = [[notification object] responseString];
     } else if (notification.userInfo) {
-        responseObject = notification.userInfo[AFNetworkingTaskDidCompleteSerializedResponseKey];
+        responseObject = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:notification.userInfo[AFNetworkingTaskDidCompleteSerializedResponseKey]
+                                                                                        options:NSJSONWritingPrettyPrinted
+                                                                                          error:nil]
+                                               encoding:NSUTF8StringEncoding];
     }
 
     NSTimeInterval elapsedTime = [[NSDate date] timeIntervalSinceDate:objc_getAssociatedObject(notification.object, AFNetworkRequestStartDate)];


### PR DESCRIPTION
When the dictionary contains Unicode string like  Chinese "开启测试模式", it will print like this "\U5f00\U542f\U6d4b\U8bd5\U6a21\U5f0f". This pull request will resolve this problem.