### PR TITLE
to print the Unicode string in Dictionary

### DIFF
--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.m
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.m
@@ -158,6 +158,12 @@ static void * AFNetworkRequestStartDate = &AFNetworkRequestStartDate;
         responseObject = [[notification object] responseString];
     } else if (notification.userInfo) {
         responseObject = notification.userInfo[AFNetworkingTaskDidCompleteSerializedResponseKey];
+        if ([responseObject isKindOfClass:[NSDictionary class]]) {
+            responseObject = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:responseObject
+                                                                                            options:NSJSONWritingPrettyPrinted
+                                                                                              error:nil]
+                                                   encoding:NSUTF8StringEncoding];
+        }
     }
 
     NSTimeInterval elapsedTime = [[NSDate date] timeIntervalSinceDate:objc_getAssociatedObject(notification.object, AFNetworkRequestStartDate)];


### PR DESCRIPTION
When the dictionary contains Unicode string like  Chinese "开启测试模式", it will print like this "\U5f00\U542f\U6d4b\U8bd5\U6a21\U5f0f". This pull request will resolve this problem.