### PR TITLE
Abstracted logging call

### DIFF
--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.h
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.h
@@ -31,6 +31,8 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestLoggerLevel) {
   AFLoggerLevelFatal = AFLoggerLevelOff,
 };
 
+typedef void (^AFLoggerCall)(NSString *logString);
+
 /**
  `AFNetworkActivityLogger` logs requests and responses made by AFNetworking, with an adjustable level of detail.
  
@@ -53,6 +55,11 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestLoggerLevel) {
  @discussion Each notification has an associated `NSURLRequest`. To filter out request and response logging, such as all network activity made to a particular domain, this predicate can be set to match against the appropriate URL string pattern.
  */
 @property (nonatomic, strong) NSPredicate *filterPredicate;
+
+/**
+ The block that implements the call to NSLog or a different Logging method
+ */
+@property (nonatomic, copy) AFLoggerCall logCallback;
 
 /**
  Returns the shared logger instance.

--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.m
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.m
@@ -73,7 +73,9 @@ static NSError * AFNetworkErrorFromNotification(NSNotification *notification) {
     if (!self) {
         return nil;
     }
-
+    self.logCallback = ^void(NSString *logString) {
+        NSLog(logString, nil);
+    };
     self.level = AFLoggerLevelInfo;
 
     return self;
@@ -123,10 +125,16 @@ static void * AFNetworkRequestStartDate = &AFNetworkRequestStartDate;
 
     switch (self.level) {
         case AFLoggerLevelDebug:
-            NSLog(@"%@ '%@': %@ %@", [request HTTPMethod], [[request URL] absoluteString], [request allHTTPHeaderFields], body);
+            self.logCallback([NSString stringWithFormat:@"%@ '%@': %@ %@",
+                              [request HTTPMethod],
+                              [[request URL] absoluteString],
+                              [request allHTTPHeaderFields],
+                              body]);
             break;
         case AFLoggerLevelInfo:
-            NSLog(@"%@ '%@'", [request HTTPMethod], [[request URL] absoluteString]);
+            self.logCallback([NSString stringWithFormat:@"%@ '%@'",
+                              [request HTTPMethod],
+                              [[request URL] absoluteString]]);
             break;
         default:
             break;
@@ -168,17 +176,30 @@ static void * AFNetworkRequestStartDate = &AFNetworkRequestStartDate;
             case AFLoggerLevelInfo:
             case AFLoggerLevelWarn:
             case AFLoggerLevelError:
-                NSLog(@"[Error] %@ '%@' (%ld) [%.04f s]: %@", [request HTTPMethod], [[response URL] absoluteString], (long)responseStatusCode, elapsedTime, error);
+                self.logCallback([NSString stringWithFormat:@"[Error] %@ '%@' (%ld) [%.04f s]: %@",
+                                  [request HTTPMethod],
+                                  [[response URL] absoluteString],
+                                  (long)responseStatusCode,
+                                  elapsedTime,
+                                  error]);
             default:
                 break;
         }
     } else {
         switch (self.level) {
             case AFLoggerLevelDebug:
-                NSLog(@"%ld '%@' [%.04f s]: %@ %@", (long)responseStatusCode, [[response URL] absoluteString], elapsedTime, responseHeaderFields, responseObject);
+                self.logCallback([NSString stringWithFormat:@"%ld '%@' [%.04f s]: %@ %@",
+                                  (long)responseStatusCode,
+                                  [[response URL] absoluteString],
+                                  elapsedTime,
+                                  responseHeaderFields,
+                                  responseObject]);
                 break;
             case AFLoggerLevelInfo:
-                NSLog(@"%ld '%@' [%.04f s]", (long)responseStatusCode, [[response URL] absoluteString], elapsedTime);
+                self.logCallback([NSString stringWithFormat:@"%ld '%@' [%.04f s]",
+                                  (long)responseStatusCode,
+                                  [[response URL] absoluteString],
+                                  elapsedTime]);
                 break;
             default:
                 break;

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ If the default logging level is too verbose—say, if you only want to know when
 [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelError];
 ```
 
+To use a different logging method with the derived log string you can initialize a callback block:
+
+``` objective-c
+[AFNetworkActivityLogger sharedLogger].logCallback = ^(NSString *logString) {
+  CLS_LOG(@"%@", logString);
+};
+```
+
+
 ## Contact
 
 Mattt Thompson


### PR DESCRIPTION
The reason for this change is to allow the usage of different logging libraries/methods instead of always using NSLog.