### PR TITLE
Add indicator for HTTPBodyStream in AFLoggerLevelDebug

### DIFF
--- a/AFNetworkActivityLogger/AFNetworkActivityLogger.m
+++ b/AFNetworkActivityLogger/AFNetworkActivityLogger.m
@@ -121,9 +121,14 @@ static void * AFNetworkRequestStartDate = &AFNetworkRequestStartDate;
         body = [[NSString alloc] initWithData:[request HTTPBody] encoding:NSUTF8StringEncoding];
     }
 
+    NSString *stream = nil;
+    if ([request HTTPBodyStream]) {
+        stream = @"<stream>";
+    }
+
     switch (self.level) {
         case AFLoggerLevelDebug:
-            NSLog(@"%@ '%@': %@ %@", [request HTTPMethod], [[request URL] absoluteString], [request allHTTPHeaderFields], body);
+            NSLog(@"%@ '%@': %@ %@ %@", [request HTTPMethod], [[request URL] absoluteString], [request allHTTPHeaderFields], body, stream);
             break;
         case AFLoggerLevelInfo:
             NSLog(@"%@ '%@'", [request HTTPMethod], [[request URL] absoluteString]);


### PR DESCRIPTION
This pull requests adds a simple indicator for `HTTPBodyStream` 

Before

``` objc
2016-01-13 11:36:44.121 CI[62672:24399047] POST 'http://domain.com: {
    Accept = "application/json";
    "Accept-Language" = "en-US;q=1";
    "Content-Length" = 93550;
    "Content-Type" = "multipart/form-data; boundary=Boundary+584B0429899C6289";    
} (null) 
```

after

``` objc
2016-01-13 11:36:44.121 CI[62672:24399047] POST 'http://domain.com': {
    Accept = "application/json";
    "Accept-Language" = "en-US;q=1";
    "Content-Length" = 93550;
    "Content-Type" = "multipart/form-data; boundary=Boundary+584B0429899C6289";
} (null) <stream>
```
