### PR TITLE
Updated AFNetworkActivityLogger podspec dependency to AFNetworking 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ matrix:
       env: FASTLANE_ENV=osx
     - osx_image: xcode8.3
       env: FASTLANE_ENV=ios10_xcode8
-    - osx_image: xcode7.3
-      env: FASTLANE_ENV=ios9_xcode7
-    - osx_image: xcode7.3
-      env: FASTLANE_ENV=ios8_xcode7
 before_install:
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - gem uninstall bundler -v '>1.12.5' --force --executables || echo "bundler >1.12.5 is not installed"

--- a/AFNetworkActivityLogger.podspec
+++ b/AFNetworkActivityLogger.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name     = 'AFNetworkActivityLogger'
-  s.version  = '3.0.0'
+  s.version  = '4.0.0'
   s.license  = 'MIT'
-  s.summary  = 'AFNetworking 3.0 Extension for Network Request Logging'
+  s.summary  = 'AFNetworking 4.0 Extension for Network Request Logging'
   s.homepage = 'https://github.com/AFNetworking/AFNetworkActivityLogger'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/AFNetworking/AFNetworkActivityLogger.git', :tag => s.version }
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.dependency 'AFNetworking/NSURLSession', '~> 3.0'
+  s.dependency 'AFNetworking/NSURLSession', '~> 4.0'
 end

--- a/AFNetworkActivityLogger.podspec
+++ b/AFNetworkActivityLogger.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/AFNetworking/AFNetworkActivityLogger.git', :tag => s.version }
   s.source_files = 'AFNetworkActivityLogger'
   s.requires_arc = true
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-This is a fork of AFNetworkActivityLogger with an updated podspec to work with AFNetworking 4.0.
-
 # AFNetworkActivityLogger
 
 `AFNetworkActivityLogger` is an extension for [AFNetworking](http://github.com/AFNetworking/AFNetworking/) 4.0 that logs network requests as they are sent and received.
 
 > `AFNetworkActivityLogger` listens `AFNetworkingTaskDidStartNotification` and `AFNetworkingTaskDidFinishNotification` notifications, which are posted by AFNetworking as session tasks are started and finish. For further customization of logging output, users are encouraged to implement desired functionality by creating new objects that conform to `AFNetworkActivityLoggerProtocol`.
 
-## 2.x -> 3.x Migration
+## 2.x -> 4.x Migration
 3.0.0 featured the following breaking API changes:
 
 * The log `level` property is now found on the individual unique loggers, rather than the shared logger. This allows for more advanced customization options for logging level.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+This is a fork of AFNetworkActivityLogger with an updated podspec to work with AFNetworking 4.0.
+
 # AFNetworkActivityLogger
 
-`AFNetworkActivityLogger` is an extension for [AFNetworking](http://github.com/AFNetworking/AFNetworking/) 3.0 that logs network requests as they are sent and received.
+`AFNetworkActivityLogger` is an extension for [AFNetworking](http://github.com/AFNetworking/AFNetworking/) 4.0 that logs network requests as they are sent and received.
 
 > `AFNetworkActivityLogger` listens `AFNetworkingTaskDidStartNotification` and `AFNetworkingTaskDidFinishNotification` notifications, which are posted by AFNetworking as session tasks are started and finish. For further customization of logging output, users are encouraged to implement desired functionality by creating new objects that conform to `AFNetworkActivityLoggerProtocol`.
 


### PR DESCRIPTION
This just updates AFNetworkActivityLogger's podspec to work with AFNetworking 4.0.